### PR TITLE
feat: add jaeger as tracing data store

### DIFF
--- a/tracetest/collector.config.yaml
+++ b/tracetest/collector.config.yaml
@@ -1,28 +1,28 @@
 receivers:
-    otlp:
-        protocols:
-            grpc:
-            http:
-              cors:
-                allowed_origins:
-                - http://localhost:1234
+  otlp:
+    protocols:
+      grpc:
+      http:
+        cors:
+          allowed_origins:
+            - http://localhost:1234
 processors:
-    batch:
-        timeout: 100ms
+  batch:
+    timeout: 100ms
 exporters:
-    logging:
-        loglevel: debug
-    otlp/1:
-        endpoint: tracetest:4317
-        tls:
-            insecure: true
+  logging:
+    loglevel: debug
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
 service:
-    pipelines:
-        traces/1:
-            receivers:
-                - otlp
-            processors:
-                - batch
-            exporters:
-                - logging
-                - otlp/1
+  pipelines:
+    traces/1:
+      receivers:
+        - otlp
+      processors:
+        - batch
+      exporters:
+        - logging
+        - jaeger

--- a/tracetest/docker-compose.yaml
+++ b/tracetest/docker-compose.yaml
@@ -75,6 +75,17 @@ services:
             - type: bind
               source: ./tracetest-provision.yaml
               target: /app/provision.yaml
+    jaeger:
+        image: jaegertracing/all-in-one:latest
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD", "wget", "--spider", "localhost:16686"]
+            interval: 1s
+            timeout: 3s
+            retries: 60
+        ports:
+            - 16685:16685
+            - 16686:16686
 networks:
     default:
         name: _default

--- a/tracetest/tracetest-provision.yaml
+++ b/tracetest/tracetest-provision.yaml
@@ -1,10 +1,12 @@
 ---
 type: DataStore
 spec:
-  name: otlp
-  type: otlp
-  otlp:
-    type: otlp
+  name: jaeger
+  type: jaeger
+  jaeger:
+    endpoint: jaeger:16685
+    tls:
+      insecure: true
 ---
 type: Config
 spec:


### PR DESCRIPTION
This PR adds jaeger as a tracing data store for Tracetest.

Demo video: https://www.loom.com/share/5f4ad0ed9f95423a9d1487319a40db42